### PR TITLE
Fix StopwatchTickProvider from mixing Timespan ticks and Stopwatch ticks

### DIFF
--- a/src/NewId.Tests/NewId.Tests.csproj
+++ b/src/NewId.Tests/NewId.Tests.csproj
@@ -55,6 +55,7 @@
     <Compile Include="LongTerm_Specs.cs" />
     <Compile Include="NetworkAddress_Specs.cs" />
     <Compile Include="NewId_Specs.cs" />
+    <Compile Include="Provider_Specs.cs" />
     <Compile Include="Usage_Specs.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/NewId.Tests/Provider_Specs.cs
+++ b/src/NewId.Tests/Provider_Specs.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Threading;
+using MassTransit.NewIdProviders;
+using NUnit.Framework;
+
+namespace MassTransit.NewIdTests
+{
+    [TestFixture]
+    public class StopwatchTickProvider_Specs
+    {
+        [Test, Explicit]
+        public void Should_not_lag_time()
+        {
+            TimeSpan timeDelta = TimeSpan.FromMinutes(1);
+
+            StopwatchTickProvider startProvider = new StopwatchTickProvider();
+            Thread.Sleep(timeDelta);
+            StopwatchTickProvider endProvider = new StopwatchTickProvider();
+
+            long deltaTicks = Math.Abs(endProvider.Ticks - startProvider.Ticks);
+            // 0.01% acceptable delta
+            long acceptableDelta = (long)(timeDelta.Ticks * 0.0001);
+
+            Assert.Less(deltaTicks, acceptableDelta);
+        }
+    }
+}

--- a/src/NewId/NewIdProviders/StopwatchTickProvider.cs
+++ b/src/NewId/NewIdProviders/StopwatchTickProvider.cs
@@ -7,6 +7,7 @@ namespace MassTransit.NewIdProviders
     public class StopwatchTickProvider :
         ITickProvider
     {
+
         readonly Stopwatch _stopwatch;
         DateTime _start;
 
@@ -16,9 +17,33 @@ namespace MassTransit.NewIdProviders
             _stopwatch = Stopwatch.StartNew();
         }
 
+        private static readonly double StopwatchTickFrequency;
+
+        static StopwatchTickProvider()
+        {
+            if (Stopwatch.IsHighResolution)
+            {
+                StopwatchTickFrequency = TimeSpan.TicksPerSecond / (double)Stopwatch.Frequency;
+            }
+            else
+            {
+                StopwatchTickFrequency = 1.0;
+            }
+        }
+
         public long Ticks
         {
-            get { return _start.AddTicks(_stopwatch.ElapsedTicks).Ticks; }
+            get { return _start.AddTicks(GetStopwatchTicksAsTimespanTicks()).Ticks; }
+        }
+
+        // Stopwatch and Timespan ticks are not the same
+        long GetStopwatchTicksAsTimespanTicks()
+        {
+            long rawTicks = _stopwatch.ElapsedTicks;
+            if (Stopwatch.IsHighResolution)
+                return (long)(rawTicks * StopwatchTickFrequency);
+            else
+                return rawTicks;
         }
     }
 }


### PR DESCRIPTION
Now providing maximum allowable precision
