### PR TITLE
Add ProcessorId Provider

### DIFF
--- a/src/NewId.Tests/Generator_Specs.cs
+++ b/src/NewId.Tests/Generator_Specs.cs
@@ -1,0 +1,103 @@
+﻿namespace MassTransit.NewIdTests
+{
+    using Moq;
+    using NUnit.Framework;
+    using System;
+    using System.Diagnostics;
+
+    [TestFixture]
+    public class When_generating_id
+    {
+        Mock<ITickProvider> _tickProviderMock;
+        Mock<IWorkerIdProvider> _workerIdProviderMock;
+        Mock<IProcessIdProvider> _processIdProviderMock;
+        DateTime _start;
+        Stopwatch _stopwatch;
+
+        [SetUp]
+        public void Init()
+        {
+            _tickProviderMock = new Mock<ITickProvider>();
+            _workerIdProviderMock = new Mock<IWorkerIdProvider>();
+            _processIdProviderMock = new Mock<IProcessIdProvider>();
+            _start = DateTime.UtcNow;
+            _stopwatch = Stopwatch.StartNew();
+        }
+
+        private long GetTicks()
+        {
+            return (_start.AddTicks(_stopwatch.Elapsed.Ticks)).Ticks;
+        }
+
+        [Test]
+        public void Should_not_match_when_processor_id_provided()
+        {
+            // Arrange
+            var ticks = GetTicks();
+            var networkPhysicalAddress = BitConverter.GetBytes(1234567890L);
+            var processorId = BitConverter.GetBytes(10);
+
+            _tickProviderMock.SetupGet(x => x.Ticks).Returns(ticks);
+            _workerIdProviderMock.Setup(x => x.GetWorkerId(0)).Returns(networkPhysicalAddress);
+            _processIdProviderMock.Setup(x => x.GetProcessId()).Returns(processorId);
+
+            var generator1 = new NewIdGenerator(_tickProviderMock.Object, _workerIdProviderMock.Object);
+            var generator2 = new NewIdGenerator(_tickProviderMock.Object, _workerIdProviderMock.Object, _processIdProviderMock.Object);
+
+            // Act
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            // Assert
+            Assert.AreNotEqual(id1, id2);
+            _processIdProviderMock.Verify(x => x.GetProcessId(), Times.Once());
+        }
+
+        [Test]
+        public void Should_not_match_when_generated_from_two_processes()
+        {
+            // Arrange
+            var ticks = GetTicks();
+            var networkPhysicalAddress = BitConverter.GetBytes(1234567890L);
+            var processorId = 10;
+
+            _tickProviderMock.SetupGet(x => x.Ticks).Returns(ticks);
+            _workerIdProviderMock.Setup(x => x.GetWorkerId(0)).Returns(networkPhysicalAddress);
+            _processIdProviderMock.Setup(x => x.GetProcessId()).Returns(() => BitConverter.GetBytes(processorId++));
+
+            var generator1 = new NewIdGenerator(_tickProviderMock.Object, _workerIdProviderMock.Object, _processIdProviderMock.Object);
+            var generator2 = new NewIdGenerator(_tickProviderMock.Object, _workerIdProviderMock.Object, _processIdProviderMock.Object);
+
+            // Act
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            // Assert
+            Assert.AreNotEqual(id1, id2);
+            _processIdProviderMock.Verify(x => x.GetProcessId(), Times.Exactly(2));
+        }
+
+        [Test]
+        public void Should_match_when_all_providers_equal()
+        {
+            // Arrange
+            var ticks = GetTicks();
+            var networkPhysicalAddress = BitConverter.GetBytes(1234567890L);
+            var processorId = BitConverter.GetBytes(10);
+
+            _tickProviderMock.SetupGet(x => x.Ticks).Returns(ticks);
+            _workerIdProviderMock.Setup(x => x.GetWorkerId(0)).Returns(networkPhysicalAddress);
+            _processIdProviderMock.Setup(x => x.GetProcessId()).Returns(processorId);
+
+            var generator1 = new NewIdGenerator(_tickProviderMock.Object, _workerIdProviderMock.Object, _processIdProviderMock.Object);
+            var generator2 = new NewIdGenerator(_tickProviderMock.Object, _workerIdProviderMock.Object, _processIdProviderMock.Object);
+
+            // Act
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            // Assert
+            Assert.AreEqual(id1, id2);
+        }
+    }
+}

--- a/src/NewId.Tests/NewId.Tests.csproj
+++ b/src/NewId.Tests/NewId.Tests.csproj
@@ -36,6 +36,14 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\packages\Castle.Core.3.3.3\lib\net45\Castle.Core.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Moq, Version=4.5.28.0, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
+      <HintPath>..\packages\Moq.4.5.28\lib\net45\Moq.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
@@ -53,6 +61,7 @@
     <Compile Include="Formatter_Specs.cs" />
     <Compile Include="GuidInterop_Specs.cs" />
     <Compile Include="LongTerm_Specs.cs" />
+    <Compile Include="Generator_Specs.cs" />
     <Compile Include="NetworkAddress_Specs.cs" />
     <Compile Include="NewId_Specs.cs" />
     <Compile Include="Provider_Specs.cs" />
@@ -74,6 +83,9 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/src/NewId.Tests/NewId_Specs.cs
+++ b/src/NewId.Tests/NewId_Specs.cs
@@ -30,6 +30,24 @@
             Assert.LessOrEqual(difference, TimeSpan.FromMinutes(1));
         }
 
+        [Test, Explicit]
+        public void Should_be_able_to_extract_timestamp_with_process_id()
+        {
+            DateTime now = DateTime.UtcNow;
+            NewId.SetProcessIdProvider(new CurrentProcessIdProvider());
+            NewId id = NewId.Next();
+
+            DateTime timestamp = id.Timestamp;
+
+            Console.WriteLine("Now: {0}, Timestamp: {1}", now, timestamp);
+
+            TimeSpan difference = (timestamp - now);
+            if (difference < TimeSpan.Zero)
+                difference = difference.Negate();
+
+            Assert.LessOrEqual(difference, TimeSpan.FromMinutes(1));
+        }
+
         [Test]
         public void Should_generate_sequential_ids_quickly()
         {

--- a/src/NewId.Tests/packages.config
+++ b/src/NewId.Tests/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Castle.Core" version="3.3.3" targetFramework="net45" />
+  <package id="Moq" version="4.5.28" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
   <package id="NUnit.Runners" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/NewId/IProcessIdProvider.cs
+++ b/src/NewId/IProcessIdProvider.cs
@@ -1,0 +1,7 @@
+namespace MassTransit
+{
+    public interface IProcessIdProvider
+    {
+        byte[] GetProcessId();
+    }
+}

--- a/src/NewId/NewId.cs
+++ b/src/NewId/NewId.cs
@@ -25,6 +25,7 @@ namespace MassTransit
         static NewIdGenerator _generator;
         static ITickProvider _tickProvider;
         static IWorkerIdProvider _workerIdProvider;
+        static IProcessIdProvider _processIdProvider;
 
         readonly Int32 _a;
         readonly Int32 _b;
@@ -75,12 +76,17 @@ namespace MassTransit
 
         static NewIdGenerator Generator
         {
-            get { return _generator ?? (_generator = new NewIdGenerator(TickProvider, WorkerIdProvider)); }
+            get { return _generator ?? (_generator = new NewIdGenerator(TickProvider, WorkerIdProvider, ProcessIdProvider)); }
         }
 
         static IWorkerIdProvider WorkerIdProvider
         {
             get { return _workerIdProvider ?? (_workerIdProvider = new BestPossibleWorkerIdProvider()); }
+        }
+
+        static IProcessIdProvider ProcessIdProvider
+        {
+            get { return _processIdProvider; }
         }
 
         static ITickProvider TickProvider
@@ -313,6 +319,11 @@ namespace MassTransit
         public static void SetWorkerIdProvider(IWorkerIdProvider provider)
         {
             _workerIdProvider = provider;
+        }
+
+        public static void SetProcessIdProvider(IProcessIdProvider provider)
+        {
+            _processIdProvider = provider;
         }
 
         public static void SetTickProvider(ITickProvider provider)

--- a/src/NewId/NewId.csproj
+++ b/src/NewId/NewId.csproj
@@ -42,6 +42,7 @@
     <Compile Include="..\SolutionVersion.cs">
       <Link>Properties\SolutionVersion.cs</Link>
     </Compile>
+    <Compile Include="IProcessIdProvider.cs" />
     <Compile Include="NewIdFormatters\Base32Formatter.cs" />
     <Compile Include="NewIdFormatters\DashedHexFormatter.cs" />
     <Compile Include="NewIdFormatters\HexFormatter.cs" />
@@ -57,6 +58,7 @@
     <Compile Include="NewIdParsers\ZBase32Parser.cs" />
     <Compile Include="NewIdProviders\BestPossibleWorkerIdProvider.cs" />
     <Compile Include="NewIdProviders\DateTimeTickProvider.cs" />
+    <Compile Include="NewIdProviders\ProcessIdProvider.cs" />
     <Compile Include="NewIdProviders\HostNameHashWorkerIdProvider.cs" />
     <Compile Include="NewIdProviders\NetworkAddressWorkerIdProvider.cs" />
     <Compile Include="NewIdProviders\StopwatchTickProvider.cs" />

--- a/src/NewId/NewIdGenerator.cs
+++ b/src/NewId/NewIdGenerator.cs
@@ -14,14 +14,23 @@
         ushort _sequence;
 
 
-        public NewIdGenerator(ITickProvider tickProvider, IWorkerIdProvider workerIdProvider, int workerIndex = 0)
+        public NewIdGenerator(ITickProvider tickProvider, IWorkerIdProvider workerIdProvider, IProcessIdProvider processIdProvider = null, int workerIndex = 0)
         {
             _tickProvider = tickProvider;
 
             byte[] workerId = workerIdProvider.GetWorkerId(workerIndex);
 
             _c = workerId[0] << 24 | workerId[1] << 16 | workerId[2] << 8 | workerId[3];
-            _d = workerId[4] << 24 | workerId[5] << 16;
+
+            if(processIdProvider != null)
+            {
+                var processId = processIdProvider.GetProcessId();
+                _d = processId[0] << 24 | processId[1] << 16;
+            }
+            else
+            {
+                _d = workerId[4] << 24 | workerId[5] << 16;
+            }
         }
 
         public NewId Next()

--- a/src/NewId/NewIdProviders/ProcessIdProvider.cs
+++ b/src/NewId/NewIdProviders/ProcessIdProvider.cs
@@ -1,0 +1,21 @@
+namespace MassTransit.NewIdProviders
+{
+    using System;
+    using System.Diagnostics;
+
+    public class CurrentProcessIdProvider :
+        IProcessIdProvider
+    {
+        public byte[] GetProcessId()
+        {
+            var processId = BitConverter.GetBytes(Process.GetCurrentProcess().Id);
+
+            if(processId.Length < 2)
+            {
+                throw new InvalidOperationException("Current Process Id is of insufficient length");
+            }
+
+            return processId;
+        }
+    }
+}


### PR DESCRIPTION
A missing feature was noted in [mt groups](https://groups.google.com/forum/#!topic/masstransit-discuss/4yb2dHbBOLQ) with the possibility
for collisions when running the NewId in different processes on
the same machine. Adding the ability for a ProcessIdProvider
will fix the issue in this use case.