### PR TITLE
Add greater/less than operators to NewId

### DIFF
--- a/src/NewId.Tests/NewIdOperators_Spec.cs
+++ b/src/NewId.Tests/NewIdOperators_Spec.cs
@@ -1,0 +1,36 @@
+﻿namespace NewId.Tests
+{
+    using MassTransit;
+    using NUnit.Framework;
+
+    [TestFixture]
+    public class Using_the_newid_operators
+    {
+        [Test, Explicit]
+        public void Should_be_able_to_determine_equal_ids()
+        {
+            var id1 = new NewId("fc070000-9565-3668-e000-08d5893343c6");
+            var id2 = new NewId("fc070000-9565-3668-e000-08d5893343c6");
+
+            Assert.IsTrue(id1 == id2);
+        }
+
+        [Test, Explicit]
+        public void Should_be_able_to_determine_greater_id()
+        {
+            var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
+            var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
+
+            Assert.IsTrue(lowerId < greaterId);
+        }
+
+        [Test, Explicit]
+        public void Should_be_able_to_determine_lower_id()
+        {
+            var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
+            var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
+
+            Assert.IsFalse(lowerId > greaterId);
+        }
+    }
+}

--- a/src/NewId.Tests/NewIdOperators_Spec.cs
+++ b/src/NewId.Tests/NewIdOperators_Spec.cs
@@ -16,7 +16,7 @@
         }
 
         [Test, Explicit]
-        public void Should_be_able_to_determine_greater_id()
+        public void Should_be_able_to_determine_greater_than_id()
         {
             var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
@@ -25,7 +25,7 @@
         }
 
         [Test, Explicit]
-        public void Should_be_able_to_determine_lower_id()
+        public void Should_be_able_to_determine_less_than_id()
         {
             var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");

--- a/src/NewId.Tests/NewIdOperators_Spec.cs
+++ b/src/NewId.Tests/NewIdOperators_Spec.cs
@@ -18,19 +18,19 @@
         [Test, Explicit]
         public void Should_be_able_to_determine_greater_than_id()
         {
-            var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
+            var lessId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
 
-            Assert.IsTrue(lowerId < greaterId);
+            Assert.IsTrue(lessId < greaterId);
         }
 
         [Test, Explicit]
         public void Should_be_able_to_determine_less_than_id()
         {
-            var lowerId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
+            var lessId = new NewId("fc070000-9565-3668-e000-08d5893343c6");
             var greaterId = new NewId("fc070000-9565-3668-9180-08d589338b38");
 
-            Assert.IsFalse(lowerId > greaterId);
+            Assert.IsFalse(lessId > greaterId);
         }
     }
 }

--- a/src/NewId/NewId.cs
+++ b/src/NewId/NewId.cs
@@ -311,6 +311,16 @@ namespace MassTransit
             return !(left == right);
         }
 
+        public static bool operator <(NewId left, NewId right)
+        {
+            return left.CompareTo(right) < 0;
+        }
+
+        public static bool operator >(NewId left, NewId right)
+        {
+            return left.CompareTo(right) > 0;
+        }
+
         public static void SetGenerator(NewIdGenerator generator)
         {
             _generator = generator;


### PR DESCRIPTION
Adds greater/less than operators to NewId so CompareTo methods do not need to be called explicitly.