### PR TITLE
Ordering SQL vs ToSequentialGuid()

### DIFF
--- a/src/NewId.Tests/Generator_Specs.cs
+++ b/src/NewId.Tests/Generator_Specs.cs
@@ -23,6 +23,23 @@
         }
 
         [Test]
+        public void Should_match_when_all_providers_equal_with_guid_method()
+        {
+            // Arrange
+            var generator1 = new NewIdGenerator(_tickProvider, _workerIdProvider, _processIdProvider);
+            var generator2 = new NewIdGenerator(_tickProvider, _workerIdProvider, _processIdProvider);
+            generator1.Next().ToGuid();
+            generator2.NextGuid();
+
+            // Act
+            var id1 = generator1.Next().ToGuid();
+            var id2 = generator2.NextGuid();
+
+            // Assert
+            Assert.AreEqual(id1, id2);
+        }
+
+        [Test]
         public void Should_not_match_when_generated_from_two_processes()
         {
             // Arrange

--- a/src/NewId.Tests/GuidInterop_Specs.cs
+++ b/src/NewId.Tests/GuidInterop_Specs.cs
@@ -23,7 +23,7 @@
         [Test]
         public void Should_convert_to_guid_quickly()
         {
-            NewId n = NewId.Next();
+            NewId n = NewId.Next(2)[1]; // ensure sequence number is not 0x0000
 
             Guid g = n.ToGuid();
 
@@ -36,7 +36,7 @@
         [Test]
         public void Should_display_sequentially_for_newid()
         {
-            NewId id = NewId.Next();
+            NewId id = NewId.Next(2)[1]; // ensure sequence number is not 0x0000
 
             Console.WriteLine(id.ToString("DS"));
         }
@@ -49,6 +49,18 @@
             var n = new NewId(g.ToByteArray());
 
             var gn = new Guid(n.ToByteArray());
+
+            Assert.AreEqual(g, gn);
+        }
+
+        [Test]
+        public void Should_make_the_round_trip_successfully_via_guid()
+        {
+            Guid g = Guid.NewGuid();
+
+            var n = g.ToNewId();
+
+            var gn = n.ToGuid();
 
             Assert.AreEqual(g, gn);
         }
@@ -112,7 +124,7 @@
         [Test]
         public void Should_properly_handle_string_passthrough()
         {
-            NewId n = NewId.Next();
+            NewId n = NewId.Next(2)[1]; // ensure sequence number is not 0x0000
 
             string ns = n.ToString("D");
 
@@ -126,8 +138,9 @@
         [Test]
         public void Should_support_the_same_constructor()
         {
-            var guid = new Guid(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
-            var newid = new NewId(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
+            // ensure all bytes have a different value
+            var guid = new Guid(0x01020304, 0x0506, 0x0708, 9, 10, 11, 12, 13, 14, 15, 16);
+            var newid = new NewId(0x01020304, 0x0506, 0x0708, 9, 10, 11, 12, 13, 14, 15, 16);
 
             Assert.AreEqual(guid.ToString(), newid.ToString());
         }
@@ -135,7 +148,7 @@
         [Test]
         public void Should_work_from_newid_to_guid_to_newid()
         {
-            NewId n = NewId.Next();
+            NewId n = NewId.Next(2)[1]; // ensure sequence number is not 0x0000
 
             var g = new Guid(n.ToByteArray());
 

--- a/src/NewId.Tests/GuidInterop_Specs.cs
+++ b/src/NewId.Tests/GuidInterop_Specs.cs
@@ -56,7 +56,7 @@
         [Test]
         public void Should_match_string_output_b()
         {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 14, 15};
+            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
             var g = new Guid(bytes);
             var n = new NewId(bytes);
@@ -70,7 +70,7 @@
         [Test]
         public void Should_match_string_output_d()
         {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 14, 15};
+            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
             var g = new Guid(bytes);
             var n = new NewId(bytes);
@@ -84,7 +84,7 @@
         [Test]
         public void Should_match_string_output_n()
         {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 14, 15};
+            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
             var g = new Guid(bytes);
             var n = new NewId(bytes);
@@ -98,7 +98,7 @@
         [Test]
         public void Should_match_string_output_p()
         {
-            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 12, 14, 15};
+            var bytes = new byte[] {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
 
             var g = new Guid(bytes);
             var n = new NewId(bytes);

--- a/src/NewId.Tests/Order_Specs.cs
+++ b/src/NewId.Tests/Order_Specs.cs
@@ -1,0 +1,194 @@
+﻿namespace MassTransit.NewIdTests
+{
+    using System;
+    using System.Data.SqlTypes;
+    using System.Diagnostics;
+    using NewIdProviders;
+    using NUnit.Framework;
+
+
+    [TestFixture]
+    public class Generating_ids_and_preserve_same_order_for_sql_and_ToSequentialGuid
+    {
+        [Test]
+        public void Should_keep_them_ordered_for_sql_server_when_using_array_call()
+        {
+            var generator = new NewIdGenerator(_tickProvider, _workerIdProvider);
+            generator.Next();
+
+            int limit = 1024;
+
+            var ids = new NewId[limit];
+            generator.Next(ids, 0, limit);
+
+            for (int i = 0; i < limit - 1; i++)
+            {
+                Assert.AreNotEqual(ids[i], ids[i + 1]);
+
+                SqlGuid left = ids[i].ToGuid();
+                SqlGuid right = ids[i + 1].ToGuid();
+                Assert.Less(left, right);
+                if (i % 128 == 0)
+                    Console.WriteLine("Normal: {0} Sql: {1}", left, ids[i].ToSequentialGuid());
+            }
+        }
+
+        [Test]
+        public void Should_keep_them_ordered_for_ToSequentialGuid_when_using_array_call()
+        {
+            var generator = new NewIdGenerator(_tickProvider, _workerIdProvider);
+            generator.Next();
+
+            int limit = 1024;
+
+            var ids = new NewId[limit];
+            generator.Next(ids, 0, limit);
+
+            for (int i = 0; i < limit - 1; i++)
+            {
+                Assert.AreNotEqual(ids[i], ids[i + 1]);
+
+                Guid left = ids[i].ToSequentialGuid();
+                Guid right = ids[i + 1].ToSequentialGuid();
+                Assert.Less(left, right);
+                if (i % 128 == 0)
+                    Console.WriteLine("Sql: {0}", left);
+            }
+        }
+
+        [Test]
+        public void Should_keep_them_ordered_for_sql_server_when_using_different_mac_addresses()
+        {
+            var generator1 = new NewIdGenerator(_tickProvider, new MockNetworkProvider(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, }));
+            var generator2 = new NewIdGenerator(_tickProvider, new MockNetworkProvider(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, }));
+
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            Assert.AreNotEqual(id1, id2);
+
+            SqlGuid left = id1.ToGuid();
+            SqlGuid right = id2.ToGuid();
+            Assert.Less(left, right);
+            Console.WriteLine("Normal: {0} Sql: {1}", left, id1.ToSequentialGuid());
+            Console.WriteLine("Normal: {0} Sql: {1}", right, id2.ToSequentialGuid());
+        }
+
+        [Test]
+        public void Should_keep_them_ordered_for_ToSequentialGuid_when_using_different_mac_addresses()
+        {
+            var generator1 = new NewIdGenerator(_tickProvider, new MockNetworkProvider(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, }));
+            var generator2 = new NewIdGenerator(_tickProvider, new MockNetworkProvider(new byte[] { 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, }));
+
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            Assert.AreNotEqual(id1, id2);
+
+            Guid left = id1.ToSequentialGuid();
+            Guid right = id2.ToSequentialGuid();
+            Assert.Less(left, right);
+            Console.WriteLine("Sql: {0}", left);
+            Console.WriteLine("Sql: {0}", right);
+        }
+
+        [Test]
+        public void Should_keep_them_ordered_for_sql_server_when_using_different_processes()
+        {
+            var generator1 = new NewIdGenerator(_tickProvider, _workerIdProvider, new MockProcessIdProvider(BitConverter.GetBytes(1)));
+            var generator2 = new NewIdGenerator(_tickProvider, _workerIdProvider, new MockProcessIdProvider(BitConverter.GetBytes(256)));
+
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            Assert.AreNotEqual(id1, id2);
+
+            SqlGuid left = id1.ToGuid();
+            SqlGuid right = id2.ToGuid();
+            Assert.Less(left, right);
+            Console.WriteLine("Normal: {0} Sql: {1}", left, id1.ToSequentialGuid());
+            Console.WriteLine("Normal: {0} Sql: {1}", right, id2.ToSequentialGuid());
+        }
+
+        [Test]
+        public void Should_keep_them_ordered_for_ToSequentialGuid_when_using_different_processes()
+        {
+            var generator1 = new NewIdGenerator(_tickProvider, _workerIdProvider, new MockProcessIdProvider(BitConverter.GetBytes(1)));
+            var generator2 = new NewIdGenerator(_tickProvider, _workerIdProvider, new MockProcessIdProvider(BitConverter.GetBytes(256)));
+
+            var id1 = generator1.Next();
+            var id2 = generator2.Next();
+
+            Assert.AreNotEqual(id1, id2);
+
+            Guid left = id1.ToSequentialGuid();
+            Guid right = id2.ToSequentialGuid();
+            Assert.Less(left, right);
+            Console.WriteLine("Sql: {0}", left);
+            Console.WriteLine("Sql: {0}", right);
+        }
+
+        [SetUp]
+        public void Init()
+        {
+            _start = DateTime.UtcNow;
+            _stopwatch = Stopwatch.StartNew();
+
+            _tickProvider = new MockTickProvider(GetTicks());
+            _workerIdProvider = new MockNetworkProvider(BitConverter.GetBytes(1234567890L));
+        }
+
+        ITickProvider _tickProvider;
+        IWorkerIdProvider _workerIdProvider;
+        DateTime _start;
+        Stopwatch _stopwatch;
+
+        long GetTicks()
+        {
+            return _start.AddTicks(_stopwatch.Elapsed.Ticks).Ticks;
+        }
+
+        class MockTickProvider :
+            ITickProvider
+        {
+            public MockTickProvider(long ticks)
+            {
+                Ticks = ticks;
+            }
+
+            public long Ticks { get; }
+        }
+
+        class MockNetworkProvider :
+            IWorkerIdProvider
+        {
+            readonly byte[] _workerId;
+
+            public MockNetworkProvider(byte[] workerId)
+            {
+                _workerId = workerId;
+            }
+
+            public byte[] GetWorkerId(int index)
+            {
+                return _workerId;
+            }
+        }
+
+        class MockProcessIdProvider :
+            IProcessIdProvider
+        {
+            readonly byte[] _processId;
+
+            public MockProcessIdProvider(byte[] processId)
+            {
+                _processId = processId;
+            }
+
+            public byte[] GetProcessId()
+            {
+                return _processId;
+            }
+        }
+    }
+}

--- a/src/NewId.Tests/Order_Specs.cs
+++ b/src/NewId.Tests/Order_Specs.cs
@@ -56,6 +56,10 @@
             }
         }
 
+        #region ordering using MAC-address is currently not relevant
+
+#if ORDERING_MAC_ADDRESS
+
         [Test]
         public void Should_keep_them_ordered_for_sql_server_when_using_different_mac_addresses()
         {
@@ -92,6 +96,14 @@
             Console.WriteLine("Sql: {0}", right);
         }
 
+#endif
+
+        #endregion
+
+        #region ordering using process id is currently not relevant
+
+#if ORDERING_PROCESS_ID
+
         [Test]
         public void Should_keep_them_ordered_for_sql_server_when_using_different_processes()
         {
@@ -127,6 +139,10 @@
             Console.WriteLine("Sql: {0}", left);
             Console.WriteLine("Sql: {0}", right);
         }
+
+#endif
+
+        #endregion
 
         [SetUp]
         public void Init()

--- a/src/NewId/NewId.cs
+++ b/src/NewId/NewId.cs
@@ -75,7 +75,7 @@ namespace MassTransit
             _a = (f << 24) | (g << 16) | (h << 8) | i;
             _b = (j << 24) | (k << 16) | (d << 8) | e;
             _c = (c << 16) | b;
-            _d = a;
+            _d = (int)(a & 0xFFFF0000) | ((a >> 8) & 0x00FF) | ((a << 8) & 0xFF00);
         }
 
         static IWorkerIdProvider WorkerIdProvider => _workerIdProvider ??= new BestPossibleWorkerIdProvider();
@@ -181,8 +181,8 @@ namespace MassTransit
             bytes[6] = (byte) (_c >> 24);
             bytes[5] = (byte) _c;
             bytes[4] = (byte) (_c >> 8);
-            bytes[3] = (byte) _d;
-            bytes[2] = (byte) (_d >> 8);
+            bytes[3] = (byte) (_d >> 8);
+            bytes[2] = (byte) _d;
             bytes[1] = (byte) (_d >> 16);
             bytes[0] = (byte) (_d >> 24);
 
@@ -215,7 +215,7 @@ namespace MassTransit
 
         public Guid ToGuid()
         {
-            int a = _d;
+            int a = (int)(_d & 0xFFFF0000) | ((_d >> 8) & 0x00FF) | ((_d << 8) & 0xFF00);
             var b = (short) _c;
             var c = (short) (_c >> 16);
             var d = (byte) (_b >> 8);
@@ -265,8 +265,8 @@ namespace MassTransit
             bytes[4] = (byte) _c;
             bytes[3] = (byte) (_d >> 24);
             bytes[2] = (byte) (_d >> 16);
-            bytes[1] = (byte) (_d >> 8);
-            bytes[0] = (byte) _d;
+            bytes[1] = (byte) _d;
+            bytes[0] = (byte) (_d >> 8);
 
             return bytes;
         }
@@ -416,7 +416,7 @@ namespace MassTransit
             a = bytes[10] << 24 | bytes[11] << 16 | bytes[12] << 8 | bytes[13];
             b = bytes[14] << 24 | bytes[15] << 16 | bytes[8] << 8 | bytes[9];
             c = bytes[7] << 24 | bytes[6] << 16 | bytes[5] << 8 | bytes[4];
-            d = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
+            d = bytes[3] << 24 | bytes[2] << 16 | bytes[0] << 8 | bytes[1];
         }
     }
 }

--- a/src/NewId/NewIdGenerator.cs
+++ b/src/NewId/NewIdGenerator.cs
@@ -113,7 +113,10 @@ namespace MassTransit
             var j = (byte) (b >> 24);
             var k = (byte) (b >> 16);
 
-            return new Guid(_d | sequence, _gb, _gc, d, e, f, g, h, i, j, k);
+            // swapping high and low byte, because SQL-server is doing the wrong ordering otherwise
+            var sequenceSwapped = ((sequence << 8) | ((sequence >> 8) & 0x00FF)) & 0xFFFF;
+
+            return new Guid(_d | sequenceSwapped, _gb, _gc, d, e, f, g, h, i, j, k);
         }
 
         public ArraySegment<NewId> Next(NewId[] ids, int index, int count)


### PR DESCRIPTION
Hi, great library. It solved my problem of generating sequential GUIDs.

After using it for some time I noticed that the ordering of `SqlGuid` and `ToSequentialGuid()` is not always the same (in some edge cases).

The main problem I had was the following scenario, when generating more than 256 GUIDs using the array generation method:

```csharp
using MassTransit;
using System;
using System.Data.SqlTypes;
using System.Linq;

var array = NewId.Next(512);
var ids = array.Select(x => new SqlGuid(x.ToGuid().ToByteArray())).ToList();
Console.WriteLine("| i   | guid                                 |");
Console.WriteLine("| --- | ------------------------------------ |");
foreach (var x in ids) {
    var originalIndex = ids.IndexOf(x);
    Console.WriteLine($"| {originalIndex,3} | {x,36} |");
}

Console.WriteLine("Sorted:");
var ordered = ids.OrderBy(x => x).ToList();
Console.WriteLine("| i   | guid                                 |");
Console.WriteLine("| --- | ------------------------------------ |");
foreach (var x in ordered) {
    var originalIndex = ids.IndexOf(x);
    Console.WriteLine($"| {originalIndex,3} | {x,36} |");
}
```

Note that the IDs are not sorted in the order they were created.

The format is `mmmmssss-mmmm-mmmm-tttt-tttttttttttt`. Where `m` is the MAC-address, `t` the timestamp and `s` the sequence counter. So the interessting part for this problem is the `s` (because all others stay the same). (I've removed my MAC-address and replaced it with `x`.)

| i   | guid                                 |
| --- | ------------------------------------ |
| 0   | xxxx0000-xxxx-xxxx-15ad-08d89a158ab8 |
| 1   | xxxx0001-xxxx-xxxx-15ad-08d89a158ab8 |
| 2   | xxxx0002-xxxx-xxxx-15ad-08d89a158ab8 |
| 3   | xxxx0003-xxxx-xxxx-15ad-08d89a158ab8 |
| ... | ...                                  |
| 252 | xxxx00fc-xxxx-xxxx-15ad-08d89a158ab8 |
| 253 | xxxx00fd-xxxx-xxxx-15ad-08d89a158ab8 |
| 254 | xxxx00fe-xxxx-xxxx-15ad-08d89a158ab8 |
| 255 | xxxx00ff-xxxx-xxxx-15ad-08d89a158ab8 |
| 256 | xxxx0100-xxxx-xxxx-15ad-08d89a158ab8 |
| 257 | xxxx0101-xxxx-xxxx-15ad-08d89a158ab8 |
| 258 | xxxx0102-xxxx-xxxx-15ad-08d89a158ab8 |
| 259 | xxxx0103-xxxx-xxxx-15ad-08d89a158ab8 |
| ... | ...                                  |
| 508 | xxxx01fc-xxxx-xxxx-15ad-08d89a158ab8 |
| 509 | xxxx01fd-xxxx-xxxx-15ad-08d89a158ab8 |
| 510 | xxxx01fe-xxxx-xxxx-15ad-08d89a158ab8 |
| 511 | xxxx01ff-xxxx-xxxx-15ad-08d89a158ab8 |

After sorting it using the `SqlGuid` I got:

| i   | guid                                 |
| --- | ------------------------------------ |
| 0   | xxxx0000-xxxx-xxxx-15ad-08d89a158ab8 |
| 256 | xxxx0100-xxxx-xxxx-15ad-08d89a158ab8 |
| 1   | xxxx0001-xxxx-xxxx-15ad-08d89a158ab8 |
| 257 | xxxx0101-xxxx-xxxx-15ad-08d89a158ab8 |
| 2   | xxxx0002-xxxx-xxxx-15ad-08d89a158ab8 |
| 258 | xxxx0102-xxxx-xxxx-15ad-08d89a158ab8 |
| 3   | xxxx0003-xxxx-xxxx-15ad-08d89a158ab8 |
| 259 | xxxx0103-xxxx-xxxx-15ad-08d89a158ab8 |
| ... | ...                                  |
| 252 | xxxx00fc-xxxx-xxxx-15ad-08d89a158ab8 |
| 508 | xxxx01fc-xxxx-xxxx-15ad-08d89a158ab8 |
| 253 | xxxx00fd-xxxx-xxxx-15ad-08d89a158ab8 |
| 509 | xxxx01fd-xxxx-xxxx-15ad-08d89a158ab8 |
| 254 | xxxx00fe-xxxx-xxxx-15ad-08d89a158ab8 |
| 510 | xxxx01fe-xxxx-xxxx-15ad-08d89a158ab8 |
| 255 | xxxx00ff-xxxx-xxxx-15ad-08d89a158ab8 |
| 511 | xxxx01ff-xxxx-xxxx-15ad-08d89a158ab8 |

This pull request is not yet ready for merge, but I've created some test cases to reproduce the ordering issue.

If you'd like I will extend this merge-request so the ordering will preserve the same?