### PR TITLE
Add additional sequential GUID generation/parsing options

### DIFF
--- a/src/NewId.Benchmarks/Benchmarker.cs
+++ b/src/NewId.Benchmarks/Benchmarker.cs
@@ -21,5 +21,11 @@ namespace MassTransit.Benchmarks
         {
             return NewId.NextGuid();
         }
+
+        [Benchmark(Description = "NextSequentialGuid")]
+        public Guid GetNextSequentialGuid()
+        {
+            return NewId.NextSequentialGuid();
+        }
     }
 }

--- a/src/NewId.Tests/Generator_Specs.cs
+++ b/src/NewId.Tests/Generator_Specs.cs
@@ -1,4 +1,6 @@
-﻿namespace MassTransit.NewIdTests
+﻿using System.Linq;
+
+namespace MassTransit.NewIdTests
 {
     using System;
     using System.Diagnostics;
@@ -91,6 +93,30 @@
             NewId nid1 = id1.ToNewId();
             NewId nid2 = id2.ToNewId();
 
+        }
+
+        [Test]
+        public void Should_match_sequentially_with_sequential_guid()
+        {
+            var generator = new NewIdGenerator(_tickProvider, _workerIdProvider);
+
+            var nid = generator.Next();
+            var id1 = nid.ToSequentialGuid();
+            var id2 = generator.NextSequentialGuid();
+            var id3 = generator.NextSequentialGuid();
+
+            Assert.AreNotEqual(id1, id2);
+            Assert.AreNotEqual(id2, id3);
+            Assert.Greater(id2, id1);
+
+            Console.WriteLine(id1);
+            Console.WriteLine(id2);
+            Console.WriteLine(id3);
+
+            NewId nid1 = id1.ToNewIdFromSequential();
+            NewId nid2 = id2.ToNewIdFromSequential();
+
+            Assert.AreEqual(nid, nid1);
         }
 
         [SetUp]

--- a/src/NewId.Tests/GuidInterop_Specs.cs
+++ b/src/NewId.Tests/GuidInterop_Specs.cs
@@ -158,5 +158,37 @@
 
             Assert.AreEqual(n, ng);
         }
+
+
+        [Test]
+        public void Should_parse_newid_guid_as_newid()
+        {
+            NewId n = NewId.Next();
+
+            var g = n.ToGuid();
+
+            var ng = NewId.FromGuid(g);
+
+            Assert.AreEqual(n, ng);
+
+            // Also checks to see if this would throw
+            Assert.IsTrue(ng.Timestamp != default);
+        }
+
+        [Test]
+        public void Should_parse_sequential_guid_as_newid()
+        {
+            NewId n = NewId.Next();
+
+            var nn = n.ToGuid();
+            var g = n.ToSequentialGuid();
+
+            var ng = NewId.FromSequentialGuid(g);
+
+            Assert.AreEqual(n, ng);
+
+            // Also checks to see if this would throw
+            Assert.IsTrue(ng.Timestamp != default);
+        }
     }
 }

--- a/src/NewId/INewIdGenerator.cs
+++ b/src/NewId/INewIdGenerator.cs
@@ -8,5 +8,6 @@ namespace MassTransit
 
         ArraySegment<NewId> Next(NewId[] ids, int index, int count);
         Guid NextGuid();
+        Guid NextSequentialGuid();
     }
 }

--- a/src/NewId/NewId.cs
+++ b/src/NewId/NewId.cs
@@ -247,6 +247,22 @@ namespace MassTransit
             return new Guid(a, b, c, d, e, f, g, h, i, j, k);
         }
 
+        public static NewId FromGuid(in Guid guid)
+        {
+            var bytes = guid.ToByteArray();
+            FromByteArray(bytes, out int a, out int b, out int c, out int d);
+
+            return new NewId(a, b, c, d);
+        }
+
+        public static NewId FromSequentialGuid(in Guid guid)
+        {
+            var bytes = guid.ToByteArray();
+            FromSequentialByteArray(bytes, out int a, out int b, out int c, out int d);
+
+            return new NewId(a, b, c, d);
+        }
+
         public byte[] ToByteArray()
         {
             var bytes = new byte[16];
@@ -411,12 +427,30 @@ namespace MassTransit
             return _getGenerator().NextGuid();
         }
 
+        /// <summary>
+        /// Generate a NewId, and return it as a Guid in sequential format
+        /// </summary>
+        /// <returns></returns>
+        public static Guid NextSequentialGuid()
+        {
+            return _getGenerator().NextSequentialGuid();
+        }
+
+
         static void FromByteArray(in byte[] bytes, out Int32 a, out Int32 b, out Int32 c, out Int32 d)
         {
             a = bytes[10] << 24 | bytes[11] << 16 | bytes[12] << 8 | bytes[13];
             b = bytes[14] << 24 | bytes[15] << 16 | bytes[8] << 8 | bytes[9];
             c = bytes[7] << 24 | bytes[6] << 16 | bytes[5] << 8 | bytes[4];
             d = bytes[3] << 24 | bytes[2] << 16 | bytes[0] << 8 | bytes[1];
+        }
+
+        static void FromSequentialByteArray(in byte[] bytes, out Int32 a, out Int32 b, out Int32 c, out Int32 d)
+        {
+            a = bytes[3] << 24 | bytes[2] << 16 | bytes[1] << 8 | bytes[0];
+            b = bytes[5] << 24 | bytes[4] << 16 | bytes[7] << 8 | bytes[6];
+            c = bytes[8] << 24 | bytes[9] << 16 | bytes[10] << 8 | bytes[11];
+            d = bytes[12] << 24 | bytes[13] << 16 | bytes[15] << 8 | bytes[14];
         }
     }
 }

--- a/src/NewId/NewIdExtensions.cs
+++ b/src/NewId/NewIdExtensions.cs
@@ -2,12 +2,16 @@
 {
     using System;
 
-
     public static class NewIdExtensions
     {
         public static NewId ToNewId(this Guid guid)
         {
-            return new NewId(guid.ToByteArray());
+            return NewId.FromGuid(guid);
+        }
+
+        public static NewId ToNewIdFromSequential(this Guid guid)
+        {
+            return NewId.FromSequentialGuid(guid);
         }
     }
 }


### PR DESCRIPTION
This pull request adds additional tools for working with `NewId`s as "sequential" GUIDs, including parsing them back into valid `NewId`s and generating them directly without having to call `NewId.Next().ToSequentialGuid()`.