### PR TITLE
Intrinsics optimizations.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -75,7 +75,12 @@ Task("Test")
 
     if(data.IsRunningOnAppVeyor) settings.ArgumentCustomization = args => args.Append($"--test-adapter-path:.").Append("--logger:Appveyor");
 
+    Information($"Running {project.GetFilename()} test with SSE3 enabled");
     DotNetCoreTest(data.Paths.Directories.Solution.FullPath, settings);
+
+    settings.EnvironmentVariables["COMPlus_EnableSSE3"] = "0";
+    Information($"Running {project.GetFilename()} test with SSE3 disabled");
+    DotNetTest(data.Paths.Directories.Solution.FullPath, settings);
 });
 
 Task("Pack")

--- a/src/NewId.Benchmarks/NewId.Benchmarks.csproj
+++ b/src/NewId.Benchmarks/NewId.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RootNamespace>MassTransit.Benchmarks</RootNamespace>
     <OutputType>Exe</OutputType>
     <IsPackable>False</IsPackable>
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
   </ItemGroup>
 
 </Project>

--- a/src/NewId.Tests/NewId.Tests.csproj
+++ b/src/NewId.Tests/NewId.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <RootNamespace>MassTransit.NewIdTests</RootNamespace>
   </PropertyGroup>
 

--- a/src/NewId/NewId.csproj
+++ b/src/NewId/NewId.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <RootNamespace>MassTransit</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
## Optimizations
Added Avx/Ssse Intrinsic shuffle code to speed up operations. These changes are only internal and should not affect any public apis. All vectorized code is inside preprocessor and only runs for Sse/Avx enabled, little endian devices.

Bencharks can be [found here](https://github.com/TimothyMakkison/NewId/tree/benchmark). Note that these optimizations only apply to Intel/AMD devices. By using .Net 7 and [`Vector128.Shuffle`](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.intrinsics.vector128.shuffle?view=net-7.0) we could make these changes apply to all platforms - ie ARM.

### Benchmarks
|             Method | EnvironmentVariables |       Mean |     Error |     StdDev |     Median | Ratio | Allocated |
|------------------- |--------------------- |-----------:|----------:|-----------:|-----------:|------:|----------:|
|             ToGuid | COMPlus_EnableSSE2=0 |  14.500 ns | 0.2738 ns |  0.2427 ns |  14.538 ns |  1.00 |         - |
|             ToGuid |                Empty |   3.127 ns | 0.0530 ns |  0.0726 ns |   3.099 ns |  0.22 |         - |
|                    |                      |            |           |            |            |       |           |
|           FromGuid | COMPlus_EnableSSE2=0 |  18.707 ns | 0.3689 ns |  0.7451 ns |  18.444 ns |  1.00 |      40 B |
|           FromGuid |                Empty |   5.691 ns | 0.1130 ns |  0.3016 ns |   5.721 ns |  0.30 |         - |
|                    |                      |            |           |            |            |       |           |
|   ToSequentialGuid | COMPlus_EnableSSE2=0 |  13.527 ns | 0.2205 ns |  0.1842 ns |  13.457 ns |  1.00 |         - |
|   ToSequentialGuid |                Empty |   3.723 ns | 0.0654 ns |  0.0546 ns |   3.724 ns |  0.28 |         - |
|                    |                      |            |           |            |            |       |           |
| FromSequentialGuid | COMPlus_EnableSSE2=0 |  18.417 ns | 0.2630 ns |  0.2332 ns |  18.355 ns |  1.00 |      40 B |
| FromSequentialGuid |                Empty |   5.663 ns | 0.1097 ns |  0.2061 ns |   5.641 ns |  0.32 |         - |
|                    |                      |            |           |            |            |       |           |
|        ToByteArray | COMPlus_EnableSSE2=0 |  16.827 ns | 0.7688 ns |  2.2304 ns |  16.159 ns |  1.00 |      40 B |
|        ToByteArray |                Empty |  10.160 ns | 0.1011 ns |  0.0945 ns |  10.165 ns |  0.65 |      40 B |
|                    |                      |            |           |            |            |       |           |
|           ToString | COMPlus_EnableSSE2=0 | 122.677 ns | 6.4097 ns | 17.3291 ns | 116.874 ns |  1.00 |     192 B |
|           ToString |                Empty | 108.219 ns | 0.7087 ns |  0.6282 ns | 108.187 ns |  0.87 |     192 B |
|                    |                      |            |           |            |            |       |           |
|         FromString | COMPlus_EnableSSE2=0 |  67.828 ns | 1.3560 ns |  3.5244 ns |  67.155 ns |  1.00 |      40 B |
|         FromString |                Empty |  53.235 ns | 0.1749 ns |  0.1551 ns |  53.203 ns |  0.79 |         - |
|                    |                      |            |           |            |            |       |           |
|          FromBytes | COMPlus_EnableSSE2=0 |  15.433 ns | 0.2991 ns |  0.2652 ns |  15.438 ns |  1.00 |         - |
|          FromBytes |                Empty |   5.467 ns | 0.0448 ns |  0.0374 ns |   5.475 ns |  0.35 |         - |

### Changed
- #### ToGuid/ToSequentialGuid
- #### FromGuid/FromSequenitalGuid
- #### ToByteArray
- #### FromByteSpan/FromSequentialByteSpan
- - Used for the constructors and `ToString`
- #### ToString
- #### NewId(string)
- #### NewId(in byte[])

## Added .Net 6 target
Added .Net 6 to match other mass transit applications and enable intrinsics support.

## Updated cake
Updated the cake file to run the tests with itrinsics disabled. Not sure if this works as I've never used cake before.

## Suggestions
- Use `Span` / `ReadOnlySpan` more and target .Net Standard 2.1.
- Add `TryWriteBytes` see [Guid].(https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Guid.cs#L836)
- Use stackalloc instead of `ThreadLocal<byte[]>`.
- Add an overload for `GetSequentialFormatterArray` and `GetFormatterArray` that takes a span.
- Update `INewIdFormatter` to take a `ReadOnlySpan<byte>` instead of `in byte[]` (breaking change).
- Implement [`ISpanFormattable`](https://learn.microsoft.com/en-us/dotnet/api/system.ispanformattable?view=net-7.0) and [`ISpanParsable`](https://learn.microsoft.com/en-us/dotnet/api/system.ispanparsable-1?view=net-7.0) (.Net 7+).
- Use `string.Create`
<h3> Experimental / Future Changes</h3>

Haven't added these changes as they are uncomplete/untested, I can add them in the future.

### Vectorized Formatters
Only optimized `DashedHexFormatter` so far. I suspect there are some easy wins I haven't found yet. See changes [here](https://github.com/TimothyMakkison/NewId/blob/formatter_experiment/src/NewId/NewIdFormatters/DashedHexFormatter.cs).
|           Method |        Job | EnvironmentVariables |      Mean |    Error |   StdDev |   Median | Allocated |
|----------------- |----------- |--------------------- |----------:|---------:|---------:|---------:|----------:|
|         ToString | Job-GAJVLC | COMPlus_EnableSSE2=0 |  95.73 ns | 0.619 ns | 0.549 ns | 95.75 ns |     256 B |
| ToStringBrackets | Job-GAJVLC | COMPlus_EnableSSE2=0 | 101.85 ns | 2.134 ns | 4.861 ns | 99.10 ns |     272 B |
|         ToString | Job-LUFEVL |                Empty |  50.65 ns | 1.086 ns | 1.251 ns | 51.18 ns |      96 B |
| ToStringBrackets | Job-LUFEVL |                Empty |  49.96 ns | 0.143 ns | 0.120 ns | 49.96 ns |     104 B |

### Vectorized `NewIdGenerator` NextGuid & NextSequentialGuid
15-20% speed up. See changes [here](https://github.com/TimothyMakkison/NewId/blob/generate_guid_experiment/src/NewId/NewIdGenerator.cs).

|                 Method | EnvironmentVariables |            Mean |          Error |         StdDev |          Median | Ratio | Allocated |
|----------------------- |--------------------- |----------------:|---------------:|---------------:|----------------:|------:|----------:|
|               NextGuid | COMPlus_EnableSSE2=0 |        66.10 ns |       0.159 ns |       0.148 ns |        66.08 ns |  1.00 |         - |
|               NextGuid |                Empty |        56.75 ns |       0.841 ns |       0.786 ns |        56.36 ns |  0.86 |         - |
|                        |                      |                 |                |                |                 |       |           |
|           NextGuidBulk | COMPlus_EnableSSE2=0 | 6,592,395.50 ns | 131,697.069 ns | 156,775.992 ns | 6,520,251.56 ns |  1.00 |       5 B |
|           NextGuidBulk |                Empty | 5,515,586.85 ns |  13,901.410 ns |  10,853.307 ns | 5,521,297.66 ns |  0.84 |       5 B |
|                        |                      |                 |                |                |                 |       |           |
|     NextSequentialGuid | COMPlus_EnableSSE2=0 |        65.02 ns |       0.246 ns |       0.205 ns |        64.94 ns |  1.00 |         - |
|     NextSequentialGuid |                Empty |        57.07 ns |       0.091 ns |       0.076 ns |        57.07 ns |  0.88 |         - |
|                        |                      |                 |                |                |                 |       |           |
| NextSequentialGuidBulk | COMPlus_EnableSSE2=0 | 6,804,387.29 ns | 180,485.492 ns | 517,846.709 ns | 6,522,868.75 ns |  1.00 |       5 B |
| NextSequentialGuidBulk |                Empty | 5,525,641.91 ns |  11,878.481 ns |  10,529.964 ns | 5,527,076.95 ns |  0.77 |       5 B |