### PR TITLE
Vectorize generate guid

### DIFF
--- a/src/NewId/NewId.cs
+++ b/src/NewId/NewId.cs
@@ -11,8 +11,9 @@ namespace MassTransit
     using System.Runtime.Intrinsics;
     using System.Runtime.InteropServices;
     using System.Diagnostics;
-    using System.Buffers.Binary;
 #endif
+
+
     /// <summary>
     /// A NewId is a type that fits into the same space as a Guid/Uuid/unique identifier,
     /// but is guaranteed to be both unique and ordered, assuming it is generated using
@@ -369,7 +370,7 @@ namespace MassTransit
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
+            if (obj is null)
                 return false;
             if (obj.GetType() != typeof(NewId))
                 return false;

--- a/src/NewId/NewIdGenerator.cs
+++ b/src/NewId/NewIdGenerator.cs
@@ -2,6 +2,11 @@
 {
     using System;
     using System.Threading;
+#if NET6_0_OR_GREATER
+    using System.Runtime.CompilerServices;
+    using System.Runtime.Intrinsics;
+    using System.Runtime.Intrinsics.X86;
+#endif
 
 
     public class NewIdGenerator :
@@ -84,6 +89,18 @@
             if (lockTaken)
                 _spinLock.Exit();
 
+            // swapping high and low byte, because SQL-server is doing the wrong ordering otherwise
+            var sequenceSwapped = ((sequence << 8) | ((sequence >> 8) & 0x00FF)) & 0xFFFF;
+
+#if NET6_0_OR_GREATER
+            if (Ssse3.IsSupported && BitConverter.IsLittleEndian)
+            {
+                var vec = Vector128.Create((int)a, b, _c, _d | sequenceSwapped);
+                var result = Ssse3.Shuffle(vec.AsByte(), Vector128.Create((byte)12, 13, 14, 15, 8, 9, 10, 11, 5, 4, 3, 2, 1, 0, 7, 6));
+                return Unsafe.As<Vector128<byte>, Guid>(ref result);
+            }
+#endif
+
             var d = (byte)(b >> 8);
             var e = (byte)b;
             var f = (byte)(a >> 24);
@@ -92,9 +109,6 @@
             var i = (byte)a;
             var j = (byte)(b >> 24);
             var k = (byte)(b >> 16);
-
-            // swapping high and low byte, because SQL-server is doing the wrong ordering otherwise
-            var sequenceSwapped = ((sequence << 8) | ((sequence >> 8) & 0x00FF)) & 0xFFFF;
 
             return new Guid(_d | sequenceSwapped, _gb, _gc, d, e, f, g, h, i, j, k);
         }
@@ -114,19 +128,31 @@
             var sequence = _sequence++;
 
             var a = _a;
+#if NET6_0_OR_GREATER
+            var v = _b;
+#endif
             var b = (short)(_b >> 16);
             var c = (short)_b;
 
             if (lockTaken)
                 _spinLock.Exit();
 
+            // swapping high and low byte, because SQL-server is doing the wrong ordering otherwise
+            var sequenceSwapped = ((sequence << 8) | ((sequence >> 8) & 0x00FF)) & 0xFFFF;
+
+#if NET6_0_OR_GREATER
+            if (Ssse3.IsSupported && BitConverter.IsLittleEndian)
+            {
+                var vec = Vector128.Create((int)a, v, _c, _d | sequenceSwapped);
+                var result = Ssse3.Shuffle(vec.AsByte(), Vector128.Create((byte)0, 1, 2, 3, 6, 7, 4, 5, 11, 10, 9, 8, 15, 14, 13, 12));
+                return Unsafe.As<Vector128<byte>, Guid>(ref result);
+            }
+#endif
+
             var d = (byte)(_gc >> 8);
             var e = (byte)_gc;
             var f = (byte)(_gb >> 8);
             var g = (byte)_gb;
-
-            // swapping high and low byte, because SQL-server is doing the wrong ordering otherwise
-            var sequenceSwapped = ((sequence << 8) | ((sequence >> 8) & 0x00FF)) & 0xFFFF;
 
             var h = (byte)((_d | sequenceSwapped) >> 24);
             var i = (byte)((_d | sequenceSwapped) >> 16);

--- a/tests/NewId.Tests/Generator_Specs.cs
+++ b/tests/NewId.Tests/Generator_Specs.cs
@@ -1,6 +1,4 @@
-﻿using System.Linq;
-
-namespace MassTransit.NewIdTests
+﻿namespace MassTransit.NewIdTests
 {
     using System;
     using System.Diagnostics;
@@ -93,7 +91,6 @@ namespace MassTransit.NewIdTests
 
             NewId nid1 = id1.ToNewId();
             NewId nid2 = id2.ToNewId();
-
         }
 
         [Test]
@@ -118,6 +115,40 @@ namespace MassTransit.NewIdTests
             NewId nid2 = id2.ToNewIdFromSequential();
 
             Assert.AreEqual(nid, nid1);
+        }
+
+        [Test]
+        public void Should_generate_known_sequential_guid()
+        {
+            var expected = Guid.Parse("74b719ec-7596-3cf0-7d81-bf34437f0b01");
+            var tickProvider = new MockTickProvider(8410219332513447152);
+            var networkProvider = new MockNetworkProvider(BitConverter.GetBytes(6857996259202924925));
+            var generator = new NewIdGenerator(tickProvider, networkProvider);
+
+            for (int i = 0; i < 267; i++)
+            {
+                generator.NextSequentialGuid();
+            }
+            var guid = generator.NextSequentialGuid();
+
+            Assert.AreEqual(expected, guid);
+        }
+
+        [Test]
+        public void Should_generate_known_guid()
+        {
+            var expected = Guid.Parse("437f0b01-bf34-7d81-3cf0-74b719ec7596");
+            var tickProvider = new MockTickProvider(8410219332513447152);
+            var networkProvider = new MockNetworkProvider(BitConverter.GetBytes(6857996259202924925));
+            var generator = new NewIdGenerator(tickProvider, networkProvider);
+
+            for (int i = 0; i < 267; i++)
+            {
+                generator.NextGuid();
+            }
+            var guid = generator.NextGuid();
+
+            Assert.AreEqual(expected, guid);
         }
 
         [SetUp]
@@ -170,7 +201,6 @@ namespace MassTransit.NewIdTests
                 return _workerId;
             }
         }
-
 
         class MockProcessIdProvider :
             IProcessIdProvider

--- a/tests/NewId.Tests/NewId_Specs.cs
+++ b/tests/NewId.Tests/NewId_Specs.cs
@@ -109,7 +109,7 @@
 
             IGrouping<NewId, NewId>[] duplicates = ids.GroupBy(x => x).Where(x => x.Count() > 1).ToArray();
 
-            Console.WriteLine("Duplicates: {0}", duplicates.Count());
+            Console.WriteLine("Duplicates: {0}", duplicates.Length);
 
             foreach (IGrouping<NewId, NewId> newId in duplicates)
                 Console.WriteLine("{0} {1}", newId.Key, newId.Count());
@@ -141,7 +141,7 @@
 
             IGrouping<NewId, NewId>[] duplicates = ids.GroupBy(x => x).Where(x => x.Count() > 1).ToArray();
 
-            Console.WriteLine("Duplicates: {0}", duplicates.Count());
+            Console.WriteLine("Duplicates: {0}", duplicates.Length);
 
             foreach (IGrouping<NewId, NewId> newId in duplicates)
                 Console.WriteLine("{0} {1}", newId.Key, newId.Count());


### PR DESCRIPTION
I've made some changes to `NextGuid` and `NextSequentialGuid` to improve their performance. These changes include vectorizing the functions, which has resulted in a speed improvement of 10-15%. As NextGuid is frequently called in MassTransit, this small improvement should add up.

Also added some simple assertion tests to ensure that the changes do not break any existing functionality. Additionally, I've made some minor code improvements.

#### Benchmarks
Benchmark code can be [found here](https://github.com/TimothyMakkison/NewId/blob/vectorize_guid_benchmarks/tests/NewId.Benchmarks/NewIdBenchmarks.cs).

|                     Method | EnvironmentVariables |              Mean |             Error |            StdDev | Ratio |  Allocated |
|--------------------------- |--------------------- |------------------:|------------------:|------------------:|------:|-----------:|
|                   NextGuid | COMPlus_EnableSSE2=0 |          63.68 ns |          0.485 ns |          0.430 ns |  1.00 |          - |
|                   NextGuid |                Empty |          53.90 ns |          0.124 ns |          0.116 ns |  0.85 |          - |
|                            |                      |                   |                   |                   |       |            |
|               NextGuidBulk | COMPlus_EnableSSE2=0 |   6,499,998.33 ns |     37,311.406 ns |     33,075.590 ns |  1.00 |        5 B |
|               NextGuidBulk |                Empty |   5,517,873.10 ns |     11,506.953 ns |     10,200.614 ns |  0.85 |        5 B |
|                            |                      |                   |                   |                   |       |            |
|         NextSequentialGuid | COMPlus_EnableSSE2=0 |          62.39 ns |          0.111 ns |          0.098 ns |  1.00 |          - |
|         NextSequentialGuid |                Empty |          53.58 ns |          0.155 ns |          0.129 ns |  0.86 |          - |
|                            |                      |                   |                   |                   |       |            |
|     NextSequentialGuidBulk | COMPlus_EnableSSE2=0 |   6,379,690.66 ns |      9,309.096 ns |      7,773.517 ns |  1.00 |        5 B |
|     NextSequentialGuidBulk |                Empty |   5,520,476.59 ns |      9,472.339 ns |      8,860.432 ns |  0.87 |        5 B |
|                            |                      |                   |                   |                   |       |            |
|           NextGuidParallel | COMPlus_EnableSSE2=0 | 372,620,013.00 ns | 12,028,605.371 ns | 35,466,614.329 ns |  1.00 | 83891776 B |
|           NextGuidParallel |                Empty | 311,851,534.42 ns |  6,214,288.576 ns | 15,929,597.331 ns |  0.86 | 83891312 B |
|                            |                      |                   |                   |                   |       |            |
| NextSequentialGuidParallel | COMPlus_EnableSSE2=0 | 349,581,895.92 ns | 10,806,814.204 ns | 31,523,984.276 ns |  1.00 | 83891776 B |
| NextSequentialGuidParallel |                Empty | 324,188,729.55 ns |  6,403,590.216 ns | 15,094,015.521 ns |  0.91 | 83891312 B |


I've also experimented with a non-intrinsic version of NextGuid and NextSequentialGuid that achieves a 5-10% speed improvement, but the results are very unreliable. If anyone is interested in trying to improve upon this version, you can find the [code here](https://github.com/TimothyMakkison/NewId/blob/52aec9a17a0db87e8ef19f4c264332b36eb4f9f3/src/NewId/NewIdGenerator.cs#L105)